### PR TITLE
fix: removed duplicated administracao content in the sidebar

### DIFF
--- a/templates/accounts/signup_gestor.html
+++ b/templates/accounts/signup_gestor.html
@@ -3,18 +3,6 @@
 
 {% block title %}Novo Gestor · Karu{% endblock %}
 
-
-{% block sidebar_extra %}
-  {% if request.user.is_superuser or request.user|has_group:'gestores' %}
-    <li class="menu-title mt-4"><span>Administração</span></li>
-    {% if request.user.is_superuser %}
-      <li><a href="{% url 'accounts:signup_gestor' %}"><i data-lucide="shield-plus" class="w-5 h-5"></i> Novo Gestor</a></li>
-    {% endif %}
-    <li><a href="{% url 'accounts:signup_profissional' %}"><i data-lucide="user-plus" class="w-5 h-5"></i> Novo Profissional</a></li>
-    <li><a href="{% url 'accounts:signup_pais' %}"><i data-lucide="users" class="w-5 h-5"></i> Novo Responsável</a></li>
-  {% endif %}
-{% endblock %}
-
 {% block content %}
   <div class="max-w-4xl mx-auto p-4">
     {% if form.non_field_errors %}

--- a/templates/accounts/signup_pais.html
+++ b/templates/accounts/signup_pais.html
@@ -3,19 +3,6 @@
 
 {% block title %}Novo Responsável · Karu{% endblock %}
 
-
-
-{% block sidebar_extra %}
-  {% if request.user.is_superuser or request.user|has_group:'gestores' %}
-    <li class="menu-title mt-4"><span>Administração</span></li>
-    <li><a href="{% url 'accounts:signup_profissional' %}"><i data-lucide="user-plus" class="w-5 h-5"></i> Novo Profissional</a></li>
-    <li><a href="{% url 'accounts:signup_pais' %}"><i data-lucide="users" class="w-5 h-5"></i> Novo Responsável</a></li>
-  {% endif %}
-  {% if request.user.is_superuser %}
-    <li><a href="{% url 'accounts:signup_gestor' %}"><i data-lucide="shield-plus" class="w-5 h-5"></i> Novo Gestor</a></li>
-  {% endif %}
-{% endblock %}
-
 {% block content %}
   <div class="max-w-4xl mx-auto p-4">
     {% if form.non_field_errors %}

--- a/templates/accounts/signup_profissional.html
+++ b/templates/accounts/signup_profissional.html
@@ -3,17 +3,6 @@
 
 {% block title %}Novo Profissional · Karu{% endblock %}
 
-{% block sidebar_extra %}
-  {% if request.user.is_superuser or request.user|has_group:'gestores' %}
-    <li class="menu-title mt-4"><span>Administração</span></li>
-    <li><a href="{% url 'accounts:signup_profissional' %}"><i data-lucide="user-plus" class="w-5 h-5"></i> Novo Profissional</a></li>
-    <li><a href="{% url 'accounts:signup_pais' %}"><i data-lucide="users" class="w-5 h-5"></i> Novo Responsável</a></li>
-  {% endif %}
-  {% if request.user.is_superuser %}
-    <li><a href="{% url 'accounts:signup_gestor' %}"><i data-lucide="shield-plus" class="w-5 h-5"></i> Novo Gestor</a></li>
-  {% endif %}
-{% endblock %}
-
 {% block content %}
   <div class="max-w-5xl mx-auto p-4">
     {% if form.non_field_errors %}


### PR DESCRIPTION
Fix a mistake in the sign-up page HTML that showed a duplicated "Administração" item in the sidebar, as shown in the print.

<img width="608" height="878" alt="Screenshot from 2025-10-16 11-34-28" src="https://github.com/user-attachments/assets/f2293d09-7e09-4e8b-b887-d1777b1d3ebb" />
